### PR TITLE
元のマテリアルを編集しないように修正

### DIFF
--- a/Assets/QuickQuestAvatarConverter/Editor/QuickQuestAvatarConverter.cs
+++ b/Assets/QuickQuestAvatarConverter/Editor/QuickQuestAvatarConverter.cs
@@ -24,7 +24,7 @@ public class QuickQuestAvatarConverter : EditorWindow
             return;
         }
 
-        var materials = renderer.sharedMaterials;
+        var materials = renderer.materials;
 
         foreach( var material in materials )
         {


### PR DESCRIPTION
元のマテリアルを編集しないようにシーン上のマテリアルのみ置き換えました。
シーン上のみなので、新しくマテリアルファイルは生成されません。
Renderer.sharedMaterialsを使用することにより、ログにエラーが出ますが「シーンでしかマテリアルが変更されていない」という内容なので無視してください。